### PR TITLE
build fail in windows10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('src/pygetwindow/__init__.py', 'r') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 # Read in the README.md for the long description.
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
default encoding in windows is gbk, which will lead to this error:


```
Collecting pygetwindow (from pyautogui)
  Using cached https://files.pythonhosted.org/packages/f1/54/740939161eb3471e8f775ce9b0fcac0e54c36bf63501e51f2cd7158f587d/PyGetWindow-0.0.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\TY201811\AppData\Local\Temp\pip-install-pzgyoz0h\pygetwindow\setup.py", line 11, in <module>
        long_description = fh.read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0xa2 in position 905: illegal multibyte sequence
```