### PR TITLE
setup.py: explictly assign encoding to "utf-8" to aviod encoding problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('src/pygetwindow/__init__.py', 'r') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 # Read in the README.md for the long description.
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
In china, Windows's default charset is set as "GBK", not "utf-8". So chinese developers will face issues that we cannot install this package through pip. I just tried to clone the repo, and after this one line change, I succeed to install the package ;)

Target Issue: https://github.com/asweigart/PyGetWindow/issues/2