### PR TITLE
Add param for getWindowsWithTitle(title, equal_or_in='in')

### DIFF
--- a/src/pygetwindow/_pygetwindow_win.py
+++ b/src/pygetwindow/_pygetwindow_win.py
@@ -144,13 +144,24 @@ def getWindowsAt(x, y):
     return windowsAtXY
 
 
-def getWindowsWithTitle(title):
-    """Returns a list of Window objects that substring match ``title`` in their title text."""
+def getWindowsWithTitle(title, equal_or_in='in'):
+    """Returns a list of Window objects that substring match ``title`` in their title text.
+
+    * ``title`` (str, required): The title of the window(s).
+    * ``equal_or_in`` (str, optional): Exactly match or in the window(s) title text.
+    """
     hWndsAndTitles = _getAllTitles()
     windowObjs = []
     for hWnd, winTitle in hWndsAndTitles:
-        if title.upper() in winTitle.upper(): # do a case-insensitive match
-            windowObjs.append(Win32Window(hWnd))
+        if equal_or_in == 'in':
+            if title.upper() in winTitle.upper(): # do a case-insensitive match
+                windowObjs.append(Win32Window(hWnd))
+        elif equal_or_in == '=':
+            if title.upper() == winTitle.upper(): # do a case-insensitive match
+                windowObjs.append(Win32Window(hWnd))
+        else:
+            raise PyGetWindowException(("Error code: getWindowsWithTitle(title, equal_or_in='in')"
+                                        " equal_or_in shuould in ['in', '=']"))
     return windowObjs
 
 


### PR DESCRIPTION
For example, when I open both counter-strike and counter-strike 2 windows, then locateOnWindow will have a problem, saying, find multiple windows, actually I match the string is counter-strike, but I find counter-strike and counter-strike 2, I need to match the previous one, find a one with 2 does not need, So I added a function argument, and after testing it on my local computer, it solved the problem.